### PR TITLE
Feature/optimizations

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: 'Generate benchmark caps'
       if: steps.cache-caps.outputs.cache-hit != 'true'
-      run: pip3 install pypacker && python3 cap_maker.py
+      run: pip3 install pypacker tqdm && python3 cap_maker.py
 
     - name: 'Benchmark ethernet'
       run: ./build/run/marine_benchmark ethernet_benchmark.cap 1 | tee ethernet_benchmark.log

--- a/cap_maker.py
+++ b/cap_maker.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "pypacker",
+#     "tqdm",
+# ]
+# ///
+
 import struct
 import random
 from typing import List, Union, Type, Iterator
@@ -7,6 +16,7 @@ from pypacker.pypacker import Packet
 from pypacker.layer12 import ethernet, radiotap, ieee80211, llc
 from pypacker.layer3 import ip
 from pypacker.layer4 import tcp, udp
+from tqdm import tqdm
 
 ETHERNET_PCAP_HEADER = bytes.fromhex("D4C3B2A10200040000000000000000000000040001000000")
 RADIOTAP_PCAP_HEADER = bytes.fromhex("D4C3B2A10200040000000000000000000000040017000000")
@@ -21,7 +31,7 @@ PORTS = list(range(4000, 4020))
 PACKETS_PER_CONVERSATION = 1000
 
 # Split evenly between TCP and UDP
-CONVERSATIONS = 420
+CONVERSATIONS = 210
 
 
 def write_cap(file_path: str, packets: List[bytes], pcap_header: bytes):
@@ -62,7 +72,7 @@ def generate_cap_file(
     packet_base: Packet, conversation_count: int, cap_header: bytes, cap_name: str
 ):
     packets: List[bytes] = []
-    for _ in range(conversation_count // 2):
+    for _ in tqdm(range(conversation_count // 2), desc=f"Generating {cap_name}"):
         packets.extend(create_conversation(packet_base, tcp.TCP))
         packets.extend(create_conversation(packet_base, udp.UDP))
 

--- a/compare_bencharmks.py
+++ b/compare_bencharmks.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import sys
+from typing import Literal, Iterable
+
+
+def _parse_pps(line: str) -> float | None:
+    if "took" not in line:
+        return None
+    return float(line.split()[-2])
+
+
+def _parse_memory(line: str) -> float | None:
+    if " MB" not in line:
+        return None
+    return float(line.split()[-2])
+
+
+def _format_ratio(
+    x1: float, x2: float, better: Literal["higher", "lower"] = "higher"
+) -> str:
+    if x1 == 0:
+        return "N/A"
+    ratio = x2 / x1
+    if 0.99 <= ratio <= 1.01:
+        state = "same"
+    elif (ratio > 1 and better == "higher") or (ratio < 1 and better == "lower"):
+        state = "better"
+    else:
+        state = "worse"
+    return f"x{ratio:.2f} ({state})"
+
+
+def _is_benchmark_title(line: str) -> bool:
+    return "Benchmark" in line
+
+
+def _filter_intermediate_lines(lines: Iterable[str]) -> Iterable[str]:
+    benchmarks_section_started = False
+    for line in lines:
+        benchmarks_section_started = benchmarks_section_started or _is_benchmark_title(
+            line
+        )
+        if not benchmarks_section_started:
+            continue
+        if not line.startswith("  run"):
+            yield line
+
+
+baseline, benchmark = sys.argv[1:]
+
+for l1, l2 in zip(
+    _filter_intermediate_lines(open(baseline)),
+    _filter_intermediate_lines(open(benchmark)),
+):
+    if _is_benchmark_title(l1) and _is_benchmark_title(l2):
+        print(l1.strip(), end=":\t")
+    elif (pps1 := _parse_pps(l1)) is not None and (pps2 := _parse_pps(l2)) is not None:
+        print(_format_ratio(pps1, pps2, "higher"), end="\t")
+    elif (mem1 := _parse_memory(l1)) is not None and (
+        mem2 := _parse_memory(l2)
+    ) is not None:
+        print(_format_ratio(mem1, mem2, "lower"))

--- a/marine.c
+++ b/marine.c
@@ -298,41 +298,6 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
     data.fields = fields;
     data.edt = edt;
 
-    if (NULL == fields->field_indicies) {
-        /* Prepare a lookup table from string abbreviation for field to its index. */
-        fields->field_indicies = g_hash_table_new(g_str_hash, g_str_equal);
-
-        i = 0;
-        while (i < fields->fields->len) {
-            gchar *field = (gchar *) g_ptr_array_index(fields->fields, i);
-            /* Store field indicies +1 so that zero is not a valid value,
-             * and can be distinguished from NULL as a pointer.
-             */
-            ++i;
-            g_hash_table_insert(fields->field_indicies, field, GUINT_TO_POINTER(i));
-        }
-
-        /* Pre-compute the fixed_index mapping to avoid per-packet hash lookups */
-        filter->fixed_index_map = (unsigned int *) g_malloc(sizeof(unsigned int) * fields->fields->len);
-        for (i = 0; i < fields->fields->len; i++) {
-            gchar *field = (gchar *) g_ptr_array_index(fields->fields, i);
-            filter->fixed_index_map[i] = GPOINTER_TO_UINT(g_hash_table_lookup(fields->field_indicies, field)) - 1;
-        }
-    }
-
-    /* Array buffer to store values for this packet              */
-    /*  Allocate an array for the 'GPtrarray *' the first time   */
-    /*   ths function is invoked for a file;                     */
-    /*  Any and all 'GPtrArray *' are freed (after use) each     */
-    /*   time (each packet) this function is invoked for a flle. */
-    /* XXX: ToDo: use packet-scope'd memory & (if/when implemented) wmem ptr_array */
-    if (NULL == fields->field_values) {
-        fields->field_values = g_new0(GPtrArray * , fields->fields->len);  /* free'd in output_fields_free() */
-        for (i = 0; i < fields->fields->len; i++) {
-            fields->field_values[i] = g_ptr_array_new();
-        }
-    }
-
     proto_tree_children_foreach(edt->tree, proto_tree_get_node_field_values, &data);
 
     GHashTable *used_macros = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, NULL);
@@ -737,9 +702,34 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
     filter->output_fields = packet_output_fields;
     filter->macro_ids = macro_indices_copy;
     filter->last_in_macro = last_in_macro;
-    /* fixed_index_map is lazily initialized on first dissection and depends
-     * on output_fields->fields being immutable after filter creation. */
-    filter->fixed_index_map = NULL;
+
+    /* Pre-compute field lookup structures at filter creation time. */
+    if (packet_output_fields != NULL) {
+        gsize fi;
+        /* Build string -> index lookup table */
+        packet_output_fields->field_indicies = g_hash_table_new(g_str_hash, g_str_equal);
+        fi = 0;
+        while (fi < packet_output_fields->fields->len) {
+            gchar *field = (gchar *) g_ptr_array_index(packet_output_fields->fields, fi);
+            ++fi;
+            g_hash_table_insert(packet_output_fields->field_indicies, field, GUINT_TO_POINTER(fi));
+        }
+
+        /* Pre-compute fixed_index mapping to avoid per-packet hash lookups */
+        filter->fixed_index_map = (unsigned int *) g_malloc(sizeof(unsigned int) * packet_output_fields->fields->len);
+        for (fi = 0; fi < packet_output_fields->fields->len; fi++) {
+            gchar *field = (gchar *) g_ptr_array_index(packet_output_fields->fields, fi);
+            filter->fixed_index_map[fi] = GPOINTER_TO_UINT(g_hash_table_lookup(packet_output_fields->field_indicies, field)) - 1;
+        }
+
+        /* Pre-allocate field_values array with reusable GPtrArrays */
+        packet_output_fields->field_values = g_new0(GPtrArray *, packet_output_fields->fields->len);
+        for (fi = 0; fi < packet_output_fields->fields->len; fi++) {
+            packet_output_fields->field_values[fi] = g_ptr_array_new();
+        }
+    } else {
+        filter->fixed_index_map = NULL;
+    }
     filter->expected_output_len = output_count;
     filter->wtap_encap = wtap_encap;
     g_hash_table_insert(packet_filters, key, filter);

--- a/marine.c
+++ b/marine.c
@@ -204,6 +204,9 @@ static void format_field_values(output_fields_t *fields, gpointer field_index, g
     /* Essentially: fieldvalues[indx] is a 'GPtrArray *' with each array entry */
     /*  pointing to a string which is (part of) the final output string.       */
 
+    if (fields->field_values[indx] == NULL) {
+        fields->field_values[indx] = g_ptr_array_new();
+    }
     fv_p = fields->field_values[indx];
 
     switch (fields->occurrence) {
@@ -309,11 +312,11 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
     for (i = 0; i < fields->fields->len; ++i) {
         unsigned int fixed_index = filter->fixed_index_map[i];
 
-        if (used_macros != NULL && (g_hash_table_contains(used_macros, filter->macro_ids + i) || (g_ptr_array_len(fields->field_values[fixed_index]) == 0 && !filter->last_in_macro[i]))) {
+        if (used_macros != NULL && (g_hash_table_contains(used_macros, filter->macro_ids + i) || (fields->field_values[fixed_index] == NULL && !filter->last_in_macro[i]))) {
             continue;
         }
 
-        if (g_ptr_array_len(fields->field_values[fixed_index]) > 0) {
+        if (fields->field_values[fixed_index] != NULL && g_ptr_array_len(fields->field_values[fixed_index]) > 0) {
             GPtrArray *fv_p;
             gsize j;
             fv_p = fields->field_values[fixed_index];
@@ -341,7 +344,7 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
      * This is done in a different loop as we use fixed_index and might go over the same field twice */
     for (i = 0; i < fields->fields->len; i++) {
         GPtrArray *fv_p = fields->field_values[i];
-        if (g_ptr_array_len(fv_p) > 0) {
+        if (fv_p != NULL && g_ptr_array_len(fv_p) > 0) {
             gsize j;
             for (j = 0; j < g_ptr_array_len(fv_p); j++) {
                 g_free(g_ptr_array_index(fv_p, j));
@@ -726,11 +729,8 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
             filter->fixed_index_map[fi] = GPOINTER_TO_UINT(g_hash_table_lookup(packet_output_fields->field_indicies, field)) - 1;
         }
 
-        /* Pre-allocate field_values array with reusable GPtrArrays */
+        /* Allocate field_values pointer array (GPtrArrays created lazily per field) */
         packet_output_fields->field_values = g_new0(GPtrArray *, packet_output_fields->fields->len);
-        for (fi = 0; fi < packet_output_fields->fields->len; fi++) {
-            packet_output_fields->field_values[fi] = g_ptr_array_new();
-        }
     } else {
         filter->fixed_index_map = NULL;
     }

--- a/marine.c
+++ b/marine.c
@@ -143,6 +143,7 @@ typedef struct {
     output_fields_t *output_fields;
     int *macro_ids;
     gboolean *last_in_macro;
+    unsigned int *fixed_index_map;
     unsigned int expected_output_len;
     int wtap_encap;
 } packet_filter;
@@ -310,6 +311,13 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
             ++i;
             g_hash_table_insert(fields->field_indicies, field, GUINT_TO_POINTER(i));
         }
+
+        /* Pre-compute the fixed_index mapping to avoid per-packet hash lookups */
+        filter->fixed_index_map = (unsigned int *) g_malloc(sizeof(unsigned int) * fields->fields->len);
+        for (i = 0; i < fields->fields->len; i++) {
+            gchar *field = (gchar *) g_ptr_array_index(fields->fields, i);
+            filter->fixed_index_map[i] = GPOINTER_TO_UINT(g_hash_table_lookup(fields->field_indicies, field)) - 1;
+        }
     }
 
     /* Array buffer to store values for this packet              */
@@ -332,8 +340,7 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
     //char *output = (char *) g_malloc0(4096); // todo this can overflow
     int counter = 0;
     for (i = 0; i < fields->fields->len; ++i) {
-        gchar *field = (gchar *) g_ptr_array_index(fields->fields, i);
-        unsigned int fixed_index = GPOINTER_TO_UINT(g_hash_table_lookup(fields->field_indicies, field)) - 1;
+        unsigned int fixed_index = filter->fixed_index_map[i];
 
         if (filter->macro_ids != NULL && (g_hash_table_contains(used_macros, filter->macro_ids + i) || (g_ptr_array_len(fields->field_values[fixed_index]) == 0 && !filter->last_in_macro[i]))) {
             continue;
@@ -724,6 +731,7 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
     filter->output_fields = packet_output_fields;
     filter->macro_ids = macro_indices_copy;
     filter->last_in_macro = last_in_macro;
+    filter->fixed_index_map = NULL;
     filter->expected_output_len = output_count;
     filter->wtap_encap = wtap_encap;
     g_hash_table_insert(packet_filters, key, filter);
@@ -930,6 +938,9 @@ WS_DLL_PUBLIC void destroy_marine(void) {
         }
         if (filter->last_in_macro) {
             free(filter->last_in_macro);
+        }
+        if (filter->fixed_index_map) {
+            g_free(filter->fixed_index_map);
         }
         free(filter);
     }

--- a/marine.c
+++ b/marine.c
@@ -335,7 +335,7 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
 
     proto_tree_children_foreach(edt->tree, proto_tree_get_node_field_values, &data);
 
-    GHashTable *used_macros = g_hash_table_new(g_int_hash, g_int_equal);
+    GHashTable *used_macros = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, NULL);
 
     //char *output = (char *) g_malloc0(4096); // todo this can overflow
     int counter = 0;
@@ -642,7 +642,7 @@ WS_DLL_PUBLIC int validate_fields(char **fields, unsigned int fields_len, char *
 
 gboolean* last_seen(const int* arr, int len) {
     gboolean *ret_arr = g_new0(gboolean, len);
-    GHashTable *seen_values = g_hash_table_new(g_int_hash, g_int_equal);
+    GHashTable *seen_values = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, NULL);
 
     for (int i = len - 1; i >= 0; i--) {
         if (!g_hash_table_contains(seen_values, (arr + i))) {
@@ -724,7 +724,7 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
     int size = g_hash_table_size(packet_filters);
     int *key = g_new0(gint, 1);
     *key = size;
-    packet_filter *filter = (packet_filter *) malloc(sizeof(packet_filter));
+    packet_filter *filter = g_new0(packet_filter, 1);
     filter->has_bpf = has_bpf;
     filter->fcode = fcode;
     filter->dfcode = dfcode;
@@ -942,15 +942,15 @@ WS_DLL_PUBLIC void destroy_marine(void) {
             output_fields_free(filter->output_fields);
         }
         if (filter->macro_ids) {
-            free(filter->macro_ids);
+            g_free(filter->macro_ids);
         }
         if (filter->last_in_macro) {
-            free(filter->last_in_macro);
+            g_free(filter->last_in_macro);
         }
         if (filter->fixed_index_map) {
             g_free(filter->fixed_index_map);
         }
-        free(filter);
+        g_free(filter);
     }
 
     reset_tap_listeners();
@@ -972,10 +972,10 @@ WS_DLL_PUBLIC void marine_free(marine_result *ptr) {
             unsigned int i;
             for (i = 0; i < ptr->len; i++) {
                 if (ptr->output[i]) {
-                    free(ptr->output[i]);    
+                    g_free(ptr->output[i]);
                 }
             }
-            free(ptr->output);
+            g_free(ptr->output);
         }
         free(ptr);
     }

--- a/marine.c
+++ b/marine.c
@@ -931,6 +931,14 @@ WS_DLL_PUBLIC void destroy_marine(void) {
             dfilter_free(filter->dfcode);
         }
         if (filter->output_fields) {
+            if (filter->output_fields->field_values) {
+                for (unsigned int j = 0; j < filter->output_fields->fields->len; j++) {
+                    if (filter->output_fields->field_values[j]) {
+                        g_ptr_array_free(filter->output_fields->field_values[j], TRUE);
+                        filter->output_fields->field_values[j] = NULL;
+                    }
+                }
+            }
             output_fields_free(filter->output_fields);
         }
         if (filter->macro_ids) {

--- a/marine.c
+++ b/marine.c
@@ -200,10 +200,6 @@ static void format_field_values(output_fields_t *fields, gpointer field_index, g
     /* Unwrap change made to disambiguiate zero / null */
     indx = GPOINTER_TO_UINT(field_index) - 1;
 
-    if (fields->field_values[indx] == NULL) {
-        fields->field_values[indx] = g_ptr_array_new();
-    }
-
     /* Essentially: fieldvalues[indx] is a 'GPtrArray *' with each array entry */
     /*  pointing to a string which is (part of) the final output string.       */
 
@@ -322,8 +318,12 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
     /*  Any and all 'GPtrArray *' are freed (after use) each     */
     /*   time (each packet) this function is invoked for a flle. */
     /* XXX: ToDo: use packet-scope'd memory & (if/when implemented) wmem ptr_array */
-    if (NULL == fields->field_values)
+    if (NULL == fields->field_values) {
         fields->field_values = g_new0(GPtrArray * , fields->fields->len);  /* free'd in output_fields_free() */
+        for (i = 0; i < fields->fields->len; i++) {
+            fields->field_values[i] = g_ptr_array_new();
+        }
+    }
 
     proto_tree_children_foreach(edt->tree, proto_tree_get_node_field_values, &data);
 
@@ -339,7 +339,7 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
             continue;
         }
 
-        if (NULL != fields->field_values[fixed_index]) {
+        if (g_ptr_array_len(fields->field_values[fixed_index]) > 0) {
             GPtrArray *fv_p;
             gsize j;
             fv_p = fields->field_values[fixed_index];
@@ -366,17 +366,13 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
     /* get ready for the next packet
      * This is done in a different loop as we use fixed_index and might go over the same field twice */
     for (i = 0; i < fields->fields->len; i++) {
-        if (NULL != fields->field_values[i]) {
-            GPtrArray *fv_p;
+        GPtrArray *fv_p = fields->field_values[i];
+        if (g_ptr_array_len(fv_p) > 0) {
             gsize j;
-            fv_p = fields->field_values[i];
-
             for (j = 0; j < g_ptr_array_len(fv_p); j++) {
                 g_free(g_ptr_array_index(fv_p, j));
             }
-
-            g_ptr_array_free(fv_p, TRUE);
-            fields->field_values[i] = NULL;
+            g_ptr_array_set_size(fv_p, 0);
         }
     }
 

--- a/marine.c
+++ b/marine.c
@@ -242,7 +242,10 @@ static void format_field_values(output_fields_t *fields, gpointer field_index, g
                  * character as a separator between the previous element
                  * and this element.
                  */
-                g_ptr_array_add(fv_p, (gpointer) g_strdup_printf("%c", fields->aggregator));
+                gchar *agg = (gchar *) g_malloc(2);
+                agg[0] = fields->aggregator;
+                agg[1] = '\0';
+                g_ptr_array_add(fv_p, (gpointer) agg);
             }
             break;
         default:
@@ -338,21 +341,18 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
 
         if (NULL != fields->field_values[fixed_index]) {
             GPtrArray *fv_p;
-            gchar *str;
             gsize j;
             fv_p = fields->field_values[fixed_index];
-            output[counter] = (gchar *) g_malloc0(get_field_length(fv_p));
-            int field_counter = 0;
 
-            /* Output the array of (partial) field values */
+            output[counter] = (gchar *) g_malloc(get_field_length(fv_p));
+            gsize offset = 0;
             for (j = 0; j < g_ptr_array_len(fv_p); j++) {
-                str = (gchar *) g_ptr_array_index(fv_p, j);
-                for (char *p = str; *p != '\0'; p++) {
-                    output[counter][field_counter++] = *p;
-                }
+                gchar *str = (gchar *) g_ptr_array_index(fv_p, j);
+                gsize slen = strlen(str);
+                memcpy(output[counter] + offset, str, slen);
+                offset += slen;
             }
-
-            output[counter][field_counter] = '\0';
+            output[counter][offset] = '\0';
 
             if (filter->macro_ids != NULL) {
                 int *key = g_new(gint, 1);

--- a/marine.c
+++ b/marine.c
@@ -144,6 +144,8 @@ typedef struct {
     int *macro_ids;
     gboolean *last_in_macro;
     unsigned int *fixed_index_map;
+    GArray *hfid_array;
+    gboolean needs_visible_tree;
     unsigned int expected_output_len;
     int wtap_encap;
 } packet_filter;
@@ -281,15 +283,44 @@ static void proto_tree_get_node_field_values(proto_node *node, gpointer data) {
     }
 }
 
-gsize get_field_length(GPtrArray *field) {
-    gsize i;
-    gsize len = 1;
+/* Concatenate all parts in fv_p into a single g_malloc'd string. */
+static gchar *concat_field_parts(GPtrArray *fv_p) {
+    gsize j;
+    gsize num_parts = g_ptr_array_len(fv_p);
 
-    for (i = 0; i < g_ptr_array_len(field); i++) {
-        len += strlen((gchar *) g_ptr_array_index(field, i));
+    /* Single pass: compute total length */
+    gsize total_len = 0;
+    for (j = 0; j < num_parts; j++) {
+        total_len += strlen((gchar *) g_ptr_array_index(fv_p, j));
     }
 
-    return len;
+    /* Allocate and copy in one pass */
+    gchar *result = (gchar *) g_malloc(total_len + 1);
+    gsize offset = 0;
+    for (j = 0; j < num_parts; j++) {
+        gchar *str = (gchar *) g_ptr_array_index(fv_p, j);
+        gsize slen = strlen(str);
+        memcpy(result + offset, str, slen);
+        offset += slen;
+    }
+    result[offset] = '\0';
+    return result;
+}
+
+/*
+ * Free all reusable GPtrArrays in field_values. Called before output_fields_free
+ * because output_fields_free only frees the outer pointer array, not the
+ * individual GPtrArray instances that marine keeps alive across packets.
+ */
+static void free_field_value_arrays(output_fields_t *fields) {
+    if (!fields->field_values)
+        return;
+    for (unsigned int j = 0; j < fields->fields->len; j++) {
+        if (fields->field_values[j]) {
+            g_ptr_array_free(fields->field_values[j], TRUE);
+            fields->field_values[j] = NULL;
+        }
+    }
 }
 
 static char **
@@ -312,24 +343,15 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
     for (i = 0; i < fields->fields->len; ++i) {
         unsigned int fixed_index = filter->fixed_index_map[i];
 
-        if (used_macros != NULL && (g_hash_table_contains(used_macros, filter->macro_ids + i) || (fields->field_values[fixed_index] == NULL && !filter->last_in_macro[i]))) {
-            continue;
+        if (used_macros != NULL) {
+            gboolean macro_already_used = g_hash_table_contains(used_macros, filter->macro_ids + i);
+            gboolean field_empty_not_last = (fields->field_values[fixed_index] == NULL && !filter->last_in_macro[i]);
+            if (macro_already_used || field_empty_not_last)
+                continue;
         }
 
         if (fields->field_values[fixed_index] != NULL && g_ptr_array_len(fields->field_values[fixed_index]) > 0) {
-            GPtrArray *fv_p;
-            gsize j;
-            fv_p = fields->field_values[fixed_index];
-
-            output[counter] = (gchar *) g_malloc(get_field_length(fv_p));
-            gsize offset = 0;
-            for (j = 0; j < g_ptr_array_len(fv_p); j++) {
-                gchar *str = (gchar *) g_ptr_array_index(fv_p, j);
-                gsize slen = strlen(str);
-                memcpy(output[counter] + offset, str, slen);
-                offset += slen;
-            }
-            output[counter][offset] = '\0';
+            output[counter] = concat_field_parts(fields->field_values[fixed_index]);
 
             if (used_macros != NULL) {
                 int *key = g_new(gint, 1);
@@ -417,6 +439,9 @@ marine_process_packet(capture_file *cf, epan_dissect_t *edt, packet_filter *filt
         if (filter->dfcode)
             epan_dissect_prime_with_dfilter(edt, filter->dfcode);
 
+        if (filter->hfid_array != NULL)
+            epan_dissect_prime_with_hfid_array(edt, filter->hfid_array);
+
         /* This is the first and only pass, so prime the epan_dissect_t
            with the hfids postdissectors want on the first pass. */
         prime_epan_dissect_with_postdissector_wanted_hfids(edt);
@@ -464,10 +489,18 @@ marine_process_packet(capture_file *cf, epan_dissect_t *edt, packet_filter *filt
     return passed;
 }
 
+/*
+ * NOTE: marine is NOT thread-safe for concurrent dissection.
+ * hfinfo->ref_type (set by epan_dissect_prime_with_dfilter) is global state,
+ * not per-edt. Concurrent packets through different filters would race on
+ * ref_type. Multiple filters are safe only when used sequentially.
+ */
 static int
 marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsigned char *data, int len, char **output) {
     wtap_rec rec;
     Buffer buf;
+    /* Guard against future Wireshark versions enlarging the struct beyond
+     * a safe stack frame size. If this fails, revert to heap allocation. */
     G_STATIC_ASSERT(sizeof(epan_dissect_t) <= 4096);
     epan_dissect_t edt;
 
@@ -501,11 +534,13 @@ marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsig
     rec.rec_header.syscall_header.record_type = len;
     rec.rec_header.syscall_header.byte_order = len;
 
-    /* create_proto_tree=TRUE, proto_tree_visible=TRUE: both required for
-     * display filter evaluation and field extraction. */
-    epan_dissect_init(&edt, cf->epan, TRUE, TRUE);
+    /* Use invisible tree when possible — primed fields get fvalues populated
+     * without full tree visibility. Fall back to visible for filters that
+     * request FT_PROTOCOL or hf_text_only fields (which need fi->rep). */
+    gboolean visible = filter->needs_visible_tree;
+    epan_dissect_init(&edt, cf->epan, TRUE, visible);
 
-    reset_epan_mem(cf, &edt, 1, 1);
+    reset_epan_mem(cf, &edt, TRUE, visible);
 
     int passed = marine_process_packet(cf, &edt, filter, &buf, &rec, len, output);
 
@@ -722,17 +757,60 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
             g_hash_table_insert(packet_output_fields->field_indicies, field, GUINT_TO_POINTER(fi));
         }
 
-        /* Pre-compute fixed_index mapping to avoid per-packet hash lookups */
+        /* Pre-compute fixed_index mapping to avoid per-packet hash lookups.
+         * The hash round-trip is needed because duplicate field names may appear
+         * (g_hash_table_insert keeps the last value), causing multiple positions
+         * to alias the same underlying index. */
         filter->fixed_index_map = (unsigned int *) g_malloc(sizeof(unsigned int) * packet_output_fields->fields->len);
         for (fi = 0; fi < packet_output_fields->fields->len; fi++) {
             gchar *field = (gchar *) g_ptr_array_index(packet_output_fields->fields, fi);
             filter->fixed_index_map[fi] = GPOINTER_TO_UINT(g_hash_table_lookup(packet_output_fields->field_indicies, field)) - 1;
         }
 
+        /* Build hfid array for priming. Walk both same_name_next (forward) and
+         * same_name_prev_id (backward) to cover all registrations sharing an
+         * abbreviation. gpa_name_map stores the LAST registered hfinfo, and
+         * same_name_next links older→newer, so from the map entry we must
+         * walk backward via same_name_prev_id to reach earlier registrations. */
+        filter->hfid_array = g_array_new(FALSE, FALSE, sizeof(int));
+        filter->needs_visible_tree = FALSE;
+        GHashTable *seen_hfids = g_hash_table_new(g_direct_hash, g_direct_equal);
+        for (fi = 0; fi < packet_output_fields->fields->len; fi++) {
+            gchar *field = (gchar *) g_ptr_array_index(packet_output_fields->fields, fi);
+            header_field_info *hfi = proto_registrar_get_byname(field);
+            /* Walk forward (same_name_next) and backward (same_name_prev_id).
+             * Check ALL hfinfos for rep-dependent types (FT_PROTOCOL, hf_text_only)
+             * since different registrations of the same abbreviation can have
+             * different types. */
+            for (; hfi != NULL; hfi = hfi->same_name_next) {
+                if (hfi->type == FT_PROTOCOL || hfi->id == hf_text_only)
+                    filter->needs_visible_tree = TRUE;
+                if (!g_hash_table_contains(seen_hfids, GINT_TO_POINTER(hfi->id))) {
+                    g_hash_table_add(seen_hfids, GINT_TO_POINTER(hfi->id));
+                    g_array_append_val(filter->hfid_array, hfi->id);
+                }
+            }
+            /* Walk backward from the map entry via same_name_prev_id */
+            hfi = proto_registrar_get_byname(field);
+            while (hfi != NULL && hfi->same_name_prev_id != -1) {
+                header_field_info *prev_hfi = proto_registrar_get_nth(hfi->same_name_prev_id);
+                if (prev_hfi->type == FT_PROTOCOL || prev_hfi->id == hf_text_only)
+                    filter->needs_visible_tree = TRUE;
+                if (!g_hash_table_contains(seen_hfids, GINT_TO_POINTER(prev_hfi->id))) {
+                    g_hash_table_add(seen_hfids, GINT_TO_POINTER(prev_hfi->id));
+                    g_array_append_val(filter->hfid_array, prev_hfi->id);
+                }
+                hfi = prev_hfi;
+            }
+        }
+        g_hash_table_destroy(seen_hfids);
+
         /* Allocate field_values pointer array (GPtrArrays created lazily per field) */
         packet_output_fields->field_values = g_new0(GPtrArray *, packet_output_fields->fields->len);
     } else {
         filter->fixed_index_map = NULL;
+        filter->hfid_array = NULL;
+        filter->needs_visible_tree = FALSE;
     }
     filter->expected_output_len = output_count;
     filter->wtap_encap = wtap_encap;
@@ -933,14 +1011,7 @@ WS_DLL_PUBLIC void destroy_marine(void) {
             dfilter_free(filter->dfcode);
         }
         if (filter->output_fields) {
-            if (filter->output_fields->field_values) {
-                for (unsigned int j = 0; j < filter->output_fields->fields->len; j++) {
-                    if (filter->output_fields->field_values[j]) {
-                        g_ptr_array_free(filter->output_fields->field_values[j], TRUE);
-                        filter->output_fields->field_values[j] = NULL;
-                    }
-                }
-            }
+            free_field_value_arrays(filter->output_fields);
             output_fields_free(filter->output_fields);
         }
         if (filter->macro_ids) {
@@ -951,6 +1022,9 @@ WS_DLL_PUBLIC void destroy_marine(void) {
         }
         if (filter->fixed_index_map) {
             g_free(filter->fixed_index_map);
+        }
+        if (filter->hfid_array) {
+            g_array_free(filter->hfid_array, TRUE);
         }
         g_free(filter);
     }
@@ -1245,12 +1319,10 @@ static void marine_setup_wtap_rec(wtap_rec *rec, int len, int wtap_encap) {
 
 static epan_dissect_t *
 marine_epan_dissect_new(capture_file *cf) {
-    /* The protocol tree will be "visible", i.e., printed, only if we're
-       printing packet details, which is true if we're printing stuff
-       ("print_packet_info" is true) and we're in verbose mode
-       ("packet_details" is true). */
+    /* Full tree with visibility — used by marine_dissect_all_packet_fields
+     * which needs complete field details for proto tree extraction. */
     epan_dissect_t *edt = epan_dissect_new(cf->epan, TRUE, TRUE);
-    reset_epan_mem(cf, edt, 1, 1);
+    reset_epan_mem(cf, edt, TRUE, TRUE);
     return edt;
 }
 

--- a/marine.c
+++ b/marine.c
@@ -491,7 +491,7 @@ static int
 marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsigned char *data, int len, char **output) {
     wtap_rec rec;
     Buffer buf;
-    epan_dissect_t *edt = NULL;
+    epan_dissect_t edt;
 
     if (filter->has_bpf) {
         struct pcap_pkthdr hdr = {
@@ -523,26 +523,13 @@ marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsig
     rec.rec_header.syscall_header.record_type = len;
     rec.rec_header.syscall_header.byte_order = len;
 
+    epan_dissect_init(&edt, cf->epan, TRUE, TRUE);
 
-    /* The protocol tree will be "visible", i.e., printed, only if we're
-       printing packet details, which is true if we're printing stuff
-       ("print_packet_info" is true) and we're in verbose mode
-       ("packet_details" is true). */
-    edt = epan_dissect_new(cf->epan, TRUE, TRUE);
+    reset_epan_mem(cf, &edt, 1, 1);
 
-    /*
-     * Force synchronous resolution of IP addresses; we're doing only
-     * one pass, so we can't do it in the background and fix up past
-     * dissections.
-     */
-    //set_resolution_synchrony(TRUE); // TODO can we remove c-ares?
+    int passed = marine_process_packet(cf, &edt, filter, &buf, &rec, len, output);
 
-    reset_epan_mem(cf, edt, 1, 1);
-
-    int passed = marine_process_packet(cf, edt, filter, &buf, &rec, len, output);
-
-    if (edt)
-        epan_dissect_free(edt);
+    epan_dissect_cleanup(&edt);
 
     ws_buffer_free(&buf);
     wtap_rec_cleanup(&rec);

--- a/marine.c
+++ b/marine.c
@@ -773,16 +773,15 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
          * same_name_next links older→newer, so from the map entry we must
          * walk backward via same_name_prev_id to reach earlier registrations. */
         filter->hfid_array = g_array_new(FALSE, FALSE, sizeof(int));
-        filter->needs_visible_tree = FALSE;
         GHashTable *seen_hfids = g_hash_table_new(g_direct_hash, g_direct_equal);
         for (fi = 0; fi < packet_output_fields->fields->len; fi++) {
             gchar *field = (gchar *) g_ptr_array_index(packet_output_fields->fields, fi);
-            header_field_info *hfi = proto_registrar_get_byname(field);
-            /* Walk forward (same_name_next) and backward (same_name_prev_id).
+            header_field_info *head_hfi = proto_registrar_get_byname(field);
+            /* Walk forward via same_name_next, then backward via same_name_prev_id.
              * Check ALL hfinfos for rep-dependent types (FT_PROTOCOL, hf_text_only)
              * since different registrations of the same abbreviation can have
              * different types. */
-            for (; hfi != NULL; hfi = hfi->same_name_next) {
+            for (header_field_info *hfi = head_hfi; hfi != NULL; hfi = hfi->same_name_next) {
                 if (hfi->type == FT_PROTOCOL || hfi->id == hf_text_only)
                     filter->needs_visible_tree = TRUE;
                 if (!g_hash_table_contains(seen_hfids, GINT_TO_POINTER(hfi->id))) {
@@ -790,10 +789,10 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
                     g_array_append_val(filter->hfid_array, hfi->id);
                 }
             }
-            /* Walk backward from the map entry via same_name_prev_id */
-            hfi = proto_registrar_get_byname(field);
-            while (hfi != NULL && hfi->same_name_prev_id != -1) {
+            for (header_field_info *hfi = head_hfi; hfi != NULL && hfi->same_name_prev_id != -1; ) {
                 header_field_info *prev_hfi = proto_registrar_get_nth(hfi->same_name_prev_id);
+                if (prev_hfi == NULL)
+                    break;
                 if (prev_hfi->type == FT_PROTOCOL || prev_hfi->id == hf_text_only)
                     filter->needs_visible_tree = TRUE;
                 if (!g_hash_table_contains(seen_hfids, GINT_TO_POINTER(prev_hfi->id))) {
@@ -810,7 +809,6 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
     } else {
         filter->fixed_index_map = NULL;
         filter->hfid_array = NULL;
-        filter->needs_visible_tree = FALSE;
     }
     filter->expected_output_len = output_count;
     filter->wtap_encap = wtap_encap;

--- a/marine.c
+++ b/marine.c
@@ -300,14 +300,16 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
 
     proto_tree_children_foreach(edt->tree, proto_tree_get_node_field_values, &data);
 
-    GHashTable *used_macros = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, NULL);
+    GHashTable *used_macros = NULL;
+    if (filter->macro_ids != NULL) {
+        used_macros = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, NULL);
+    }
 
-    //char *output = (char *) g_malloc0(4096); // todo this can overflow
     int counter = 0;
     for (i = 0; i < fields->fields->len; ++i) {
         unsigned int fixed_index = filter->fixed_index_map[i];
 
-        if (filter->macro_ids != NULL && (g_hash_table_contains(used_macros, filter->macro_ids + i) || (g_ptr_array_len(fields->field_values[fixed_index]) == 0 && !filter->last_in_macro[i]))) {
+        if (used_macros != NULL && (g_hash_table_contains(used_macros, filter->macro_ids + i) || (g_ptr_array_len(fields->field_values[fixed_index]) == 0 && !filter->last_in_macro[i]))) {
             continue;
         }
 
@@ -326,7 +328,7 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
             }
             output[counter][offset] = '\0';
 
-            if (filter->macro_ids != NULL) {
+            if (used_macros != NULL) {
                 int *key = g_new(gint, 1);
                 *key = filter->macro_ids[i];
                 g_hash_table_add(used_macros, key);
@@ -348,7 +350,9 @@ marine_write_specified_fields(packet_filter *filter, epan_dissect_t *edt, char *
         }
     }
 
-    g_hash_table_destroy(used_macros);
+    if (used_macros != NULL) {
+        g_hash_table_destroy(used_macros);
+    }
 
     return output;
 }

--- a/marine.c
+++ b/marine.c
@@ -484,6 +484,8 @@ marine_process_packet(capture_file *cf, epan_dissect_t *edt, packet_filter *filt
     cf->provider.prev_cap = &prev_cap_frame;
 
     if (edt) {
+        /* epan_dissect_reset leaves edt in a state safe for
+         * epan_dissect_cleanup (called in marine_inner_dissect_packet). */
         epan_dissect_reset(edt);
         frame_data_destroy(&fdata);
     }
@@ -494,6 +496,7 @@ static int
 marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsigned char *data, int len, char **output) {
     wtap_rec rec;
     Buffer buf;
+    G_STATIC_ASSERT(sizeof(epan_dissect_t) <= 4096);
     epan_dissect_t edt;
 
     if (filter->has_bpf) {
@@ -526,12 +529,15 @@ marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsig
     rec.rec_header.syscall_header.record_type = len;
     rec.rec_header.syscall_header.byte_order = len;
 
+    /* create_proto_tree=TRUE, proto_tree_visible=TRUE: both required for
+     * display filter evaluation and field extraction. */
     epan_dissect_init(&edt, cf->epan, TRUE, TRUE);
 
     reset_epan_mem(cf, &edt, 1, 1);
 
     int passed = marine_process_packet(cf, &edt, filter, &buf, &rec, len, output);
 
+    /* Safe after epan_dissect_reset was called in marine_process_packet. */
     epan_dissect_cleanup(&edt);
 
     ws_buffer_free(&buf);
@@ -731,6 +737,8 @@ WS_DLL_PUBLIC int marine_add_filter(char *bpf, char *dfilter, char **fields, int
     filter->output_fields = packet_output_fields;
     filter->macro_ids = macro_indices_copy;
     filter->last_in_macro = last_in_macro;
+    /* fixed_index_map is lazily initialized on first dissection and depends
+     * on output_fields->fields being immutable after filter creation. */
     filter->fixed_index_map = NULL;
     filter->expected_output_len = output_count;
     filter->wtap_encap = wtap_encap;
@@ -1446,6 +1454,9 @@ static void reset_epan_mem(capture_file *cf, epan_dissect_t *edt, gboolean tree,
     epan_dissect_cleanup(edt);
     epan_free(cf->epan);
 
+    /* WARNING: output_fields and fixed_index_map on each packet_filter survive
+     * this reset. If output_fields is ever freed/recreated here,
+     * fixed_index_map must be invalidated (set to NULL). */
     cf->epan = marine_epan_new(cf);
     epan_dissect_init(edt, cf->epan, tree, visual);
     cf->count = 0;

--- a/marine.c
+++ b/marine.c
@@ -494,14 +494,13 @@ marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsig
     epan_dissect_t *edt = NULL;
 
     if (filter->has_bpf) {
-        struct pcap_pkthdr *hdr = (struct pcap_pkthdr *) malloc(sizeof(struct pcap_pkthdr));
-        hdr->len = len;
-        hdr->caplen = len;
-        if (!pcap_offline_filter(&filter->fcode, hdr, data)) {
-            free(hdr);
-            return 0;
+        struct pcap_pkthdr hdr = {
+            .len = len,
+            .caplen = len
+        };
+        if (!pcap_offline_filter(&filter->fcode, &hdr, data)) {
+            return FALSE;
         }
-        free(hdr);
         if (is_only_bpf(filter)) {
             return TRUE;
         }
@@ -514,15 +513,15 @@ marine_inner_dissect_packet(capture_file *cf, packet_filter *filter, const unsig
     memcpy(ws_buffer_start_ptr(&buf), data, len);
 
     // Fake the rec structure for internal dissection
-    (&rec)->rec_type = REC_TYPE_PACKET;
-    (&rec)->presence_flags = WTAP_HAS_CAP_LEN;
-    (&rec)->rec_header.packet_header.caplen = len;
-    (&rec)->rec_header.packet_header.len = len;
-    (&rec)->rec_header.packet_header.pkt_encap = filter->wtap_encap;
-    (&rec)->rec_header.ft_specific_header.record_len = len;
-    (&rec)->rec_header.ft_specific_header.record_type = len;
-    (&rec)->rec_header.syscall_header.record_type = len;
-    (&rec)->rec_header.syscall_header.byte_order = len;
+    rec.rec_type = REC_TYPE_PACKET;
+    rec.presence_flags = WTAP_HAS_CAP_LEN;
+    rec.rec_header.packet_header.caplen = len;
+    rec.rec_header.packet_header.len = len;
+    rec.rec_header.packet_header.pkt_encap = filter->wtap_encap;
+    rec.rec_header.ft_specific_header.record_len = len;
+    rec.rec_header.ft_specific_header.record_type = len;
+    rec.rec_header.syscall_header.record_type = len;
+    rec.rec_header.syscall_header.byte_order = len;
 
 
     /* The protocol tree will be "visible", i.e., printed, only if we're

--- a/marine.c
+++ b/marine.c
@@ -416,63 +416,37 @@ static gboolean
 marine_process_packet(capture_file *cf, epan_dissect_t *edt, packet_filter *filter, Buffer *buf, wtap_rec *rec,
                       int len, char **output) {
     frame_data fdata;
-    column_info *cinfo;
-    gboolean passed;
+    gboolean passed = TRUE;
 
-    /* Count this packet. */
     cf->count++;
-
-    /* If we're not running a display filter and we're not printing any
-       packet information, we don't need to do a dissection. This means
-       that all packets can be marked as 'passed'. */
-    passed = TRUE;
     marine_frame_data_init(&fdata, cf->count, len);
 
-    /* If we're going to print packet information, or we're going to
-       run a read filter, or we're going to process taps, set up to
-       do a dissection and do so.  (This is the one and only pass
-       over the packets, so, if we'll be printing packet information
-       or running taps, we'll be doing it here.) */
-    if (edt) {
-        /* If we're running a filter, prime the epan_dissect_t with that
-           filter. */
-        if (filter->dfcode)
-            epan_dissect_prime_with_dfilter(edt, filter->dfcode);
+    if (filter->dfcode)
+        epan_dissect_prime_with_dfilter(edt, filter->dfcode);
 
-        if (filter->hfid_array != NULL)
-            epan_dissect_prime_with_hfid_array(edt, filter->hfid_array);
+    if (filter->hfid_array != NULL)
+        epan_dissect_prime_with_hfid_array(edt, filter->hfid_array);
 
-        /* This is the first and only pass, so prime the epan_dissect_t
-           with the hfids postdissectors want on the first pass. */
-        prime_epan_dissect_with_postdissector_wanted_hfids(edt);
+    prime_epan_dissect_with_postdissector_wanted_hfids(edt);
+    col_custom_prime_edt(edt, &cf->cinfo);
 
-        col_custom_prime_edt(edt, &cf->cinfo);
-        cinfo = NULL;
-
-        //frame_data_set_before_dissect(&fdata, &cf->elapsed_time,
-        //                              &cf->provider.ref, cf->provider.prev_dis);
-        if (cf->provider.ref == &fdata) {
-            ref_frame = fdata;
-            cf->provider.ref = &ref_frame;
-        }
-
-        epan_dissect_run_with_taps(edt, cf->cd_t, rec,
-                                   frame_tvbuff_new_buffer(&cf->provider, &fdata, buf),
-                                   &fdata, cinfo);
-
-        /* Run the filter if we have it. */
-        if (filter->dfcode)
-            passed = dfilter_apply_edt(filter->dfcode, edt);
+    if (cf->provider.ref == &fdata) {
+        ref_frame = fdata;
+        cf->provider.ref = &ref_frame;
     }
+
+    epan_dissect_run_with_taps(edt, cf->cd_t, rec,
+                               frame_tvbuff_new_buffer(&cf->provider, &fdata, buf),
+                               &fdata, NULL);
+
+    if (filter->dfcode)
+        passed = dfilter_apply_edt(filter->dfcode, edt);
 
     if (passed) {
         frame_data_set_after_dissect(&fdata, &cum_bytes);
-        /* Process this packet. */
         if (filter->output_fields != NULL) {
             marine_write_specified_fields(filter, edt, output);
         }
-
-        /* this must be set after print_packet() [bug #8160] */
         prev_dis_frame = fdata;
         cf->provider.prev_dis = &prev_dis_frame;
     }
@@ -480,12 +454,10 @@ marine_process_packet(capture_file *cf, epan_dissect_t *edt, packet_filter *filt
     prev_cap_frame = fdata;
     cf->provider.prev_cap = &prev_cap_frame;
 
-    if (edt) {
-        /* epan_dissect_reset leaves edt in a state safe for
-         * epan_dissect_cleanup (called in marine_inner_dissect_packet). */
-        epan_dissect_reset(edt);
-        frame_data_destroy(&fdata);
-    }
+    /* epan_dissect_reset leaves edt in a state safe for
+     * epan_dissect_cleanup (called in marine_inner_dissect_packet). */
+    epan_dissect_reset(edt);
+    frame_data_destroy(&fdata);
     return passed;
 }
 

--- a/marine_benchmark.c
+++ b/marine_benchmark.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <time.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 #define BENCH_RUNS 7
 #define BENCH_KEEP 3
@@ -137,6 +138,182 @@ void benchmark_dissect_all_packet_fields(packet packets[], int packet_len, int e
     print_benchmark_results(avg_time, memory_start, memory_end, packet_len);
 }
 
+/* ---------- Sanity checks using hardcoded packets ---------- */
+
+static void check(int cond, const char *fmt, ...) {
+    if (cond) return;
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "\n[SANITY FAIL] ");
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+    exit(1);
+}
+
+/*
+ * Minimal Ethernet/IPv4/TCP packet (54 bytes):
+ *   dst=00:00:00:87:7e:0e  src=00:00:00:9f:f8:3b  type=0x0800
+ *   IPv4: version=4, ihl=5 (20 bytes), total_len=40, proto=6 (TCP)
+ *         src=88.44.85.145 (0x582c5591)  dst=212.110.118.170 (0xd46e76aa)
+ *   TCP:  sport=4010 (0x0faa)  dport=4011 (0x0fab)  seq=0 ack=0
+ *         data_offset=5 (20 bytes), flags=0x02 (SYN), window=65535
+ */
+static const unsigned char PKT_TCP[] = {
+    /* Ethernet header (14 bytes) */
+    0x00, 0x00, 0x00, 0x87, 0x7e, 0x0e, /* dst MAC */
+    0x00, 0x00, 0x00, 0x9f, 0xf8, 0x3b, /* src MAC */
+    0x08, 0x00,                         /* EtherType: IPv4 */
+    /* IPv4 header (20 bytes) */
+    0x45, 0x00,                         /* version=4, ihl=5, dscp=0 */
+    0x00, 0x28,                         /* total length = 40 */
+    0x00, 0x01, 0x00, 0x00,             /* id=1, flags=0, frag_offset=0 */
+    0x40, 0x06,                         /* ttl=64, proto=6 (TCP) */
+    0x00, 0x00,                         /* checksum (0 = let wireshark recalc) */
+    0x58, 0x2c, 0x55, 0x91,             /* src IP: 88.44.85.145 */
+    0xd4, 0x6e, 0x76, 0xaa,             /* dst IP: 212.110.118.170 */
+    /* TCP header (20 bytes) */
+    0x0f, 0xaa,                         /* src port: 4010 */
+    0x0f, 0xab,                         /* dst port: 4011 */
+    0x00, 0x00, 0x00, 0x00,             /* sequence number */
+    0x00, 0x00, 0x00, 0x00,             /* ack number */
+    0x50, 0x02,                         /* data offset=5, flags=SYN */
+    0xff, 0xff,                         /* window size */
+    0x00, 0x00,                         /* checksum */
+    0x00, 0x00                          /* urgent pointer */
+};
+
+/*
+ * Minimal Ethernet/IPv4/UDP packet (42 bytes):
+ *   Same Ethernet + IPv4 headers as above, but proto=17 (UDP)
+ *   UDP: sport=4010 dport=4011 len=8
+ */
+static const unsigned char PKT_UDP[] = {
+    /* Ethernet header (14 bytes) */
+    0x00, 0x00, 0x00, 0x87, 0x7e, 0x0e,
+    0x00, 0x00, 0x00, 0x9f, 0xf8, 0x3b,
+    0x08, 0x00,
+    /* IPv4 header (20 bytes) */
+    0x45, 0x00,
+    0x00, 0x1c,                         /* total length = 28 */
+    0x00, 0x02, 0x00, 0x00,
+    0x40, 0x11,                         /* ttl=64, proto=17 (UDP) */
+    0x00, 0x00,
+    0x58, 0x2c, 0x55, 0x91,
+    0xd4, 0x6e, 0x76, 0xaa,
+    /* UDP header (8 bytes) */
+    0x0f, 0xaa,                         /* src port: 4010 */
+    0x0f, 0xab,                         /* dst port: 4011 */
+    0x00, 0x08,                         /* length: 8 (header only) */
+    0x00, 0x00                          /* checksum */
+};
+
+/*
+ * Validate field extraction correctness using hardcoded packets.
+ * Runs before benchmarks; exits on failure to prevent misleading results.
+ */
+void validate_extraction(void) {
+    char *err_msg;
+    printf("Running sanity checks...\n");
+
+    /* --- 1. BPF-only: TCP packet must pass, no output --- */
+    {
+        int fid = marine_add_filter("tcp port 4010", NULL, NULL, NULL, 0, ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "BPF-only filter creation failed: %s", err_msg);
+        marine_result *r = marine_dissect_packet(fid, (unsigned char *)PKT_TCP, sizeof(PKT_TCP));
+        check(r->result == 1, "BPF-only: TCP packet did not pass");
+        check(r->output == NULL, "BPF-only: expected NULL output");
+        marine_free(r);
+    }
+
+    /* --- 2. Display-filter-only: must pass, no output --- */
+    {
+        int fid = marine_add_filter(NULL, "tcp.port == 4010", NULL, NULL, 0, ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "Display-filter-only creation failed: %s", err_msg);
+        marine_result *r = marine_dissect_packet(fid, (unsigned char *)PKT_TCP, sizeof(PKT_TCP));
+        check(r->result == 1, "Display-filter-only: packet did not pass");
+        check(r->output == NULL, "Display-filter-only: expected NULL output");
+        marine_free(r);
+    }
+
+    /* --- 3. Eight-field extraction on TCP packet --- */
+    {
+        char *fields[] = {
+            "ip.proto", "tcp.srcport", "udp.srcport", "eth.src",
+            "ip.host", "ip.hdr_len", "ip.version", "frame.encap_type"
+        };
+        int fid = marine_add_filter(NULL, NULL, fields, NULL, ARRAY_SIZE(fields), ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "Field extraction filter creation failed: %s", err_msg);
+
+        marine_result *r = marine_dissect_packet(fid, (unsigned char *)PKT_TCP, sizeof(PKT_TCP));
+        check(r->result == 1, "Field extraction: TCP packet did not pass");
+        check(r->len == 8, "Field extraction: expected 8 slots, got %u", r->len);
+
+        check(r->output[0] != NULL && strcmp(r->output[0], "6") == 0,
+              "ip.proto expected '6', got '%s'", r->output[0] ? r->output[0] : "(null)");
+        check(r->output[1] != NULL && strcmp(r->output[1], "4010") == 0,
+              "tcp.srcport expected '4010', got '%s'", r->output[1] ? r->output[1] : "(null)");
+        check(r->output[2] == NULL,
+              "udp.srcport should be NULL for TCP, got '%s'", r->output[2] ? r->output[2] : "(null)");
+        check(r->output[3] != NULL && strcmp(r->output[3], "00:00:00:9f:f8:3b") == 0,
+              "eth.src expected '00:00:00:9f:f8:3b', got '%s'", r->output[3] ? r->output[3] : "(null)");
+        check(r->output[4] != NULL,
+              "ip.host is NULL");
+        check(r->output[5] != NULL && strcmp(r->output[5], "20") == 0,
+              "ip.hdr_len expected '20', got '%s'", r->output[5] ? r->output[5] : "(null)");
+        check(r->output[6] != NULL && strcmp(r->output[6], "4") == 0,
+              "ip.version expected '4', got '%s'", r->output[6] ? r->output[6] : "(null)");
+        check(r->output[7] != NULL && strcmp(r->output[7], "1") == 0,
+              "frame.encap_type expected '1', got '%s'", r->output[7] ? r->output[7] : "(null)");
+
+        marine_free(r);
+    }
+
+    /* --- 4. Stale value: TCP then UDP — tcp.srcport must be NULL for UDP --- */
+    {
+        char *fields[] = { "ip.proto", "tcp.srcport", "udp.srcport" };
+        int fid = marine_add_filter(NULL, NULL, fields, NULL, ARRAY_SIZE(fields), ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "Stale-value filter creation failed: %s", err_msg);
+
+        marine_result *r1 = marine_dissect_packet(fid, (unsigned char *)PKT_TCP, sizeof(PKT_TCP));
+        check(r1->output[0] != NULL && strcmp(r1->output[0], "6") == 0, "Stale: TCP ip.proto != '6'");
+        check(r1->output[1] != NULL, "Stale: tcp.srcport NULL for TCP packet");
+        marine_free(r1);
+
+        marine_result *r2 = marine_dissect_packet(fid, (unsigned char *)PKT_UDP, sizeof(PKT_UDP));
+        check(r2->output[0] != NULL && strcmp(r2->output[0], "17") == 0, "Stale: UDP ip.proto != '17'");
+        check(r2->output[1] == NULL,
+              "Stale: tcp.srcport not NULL for UDP packet: '%s'", r2->output[1] ? r2->output[1] : "");
+        check(r2->output[2] != NULL && strcmp(r2->output[2], "4010") == 0,
+              "Stale: udp.srcport expected '4010', got '%s'", r2->output[2] ? r2->output[2] : "(null)");
+        marine_free(r2);
+    }
+
+    /* --- 5. epan_auto_reset boundary: fields correct across reset --- */
+    {
+        char *fields[] = { "ip.version", "frame.encap_type" };
+        int fid = marine_add_filter(NULL, NULL, fields, NULL, ARRAY_SIZE(fields), ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "Reset-boundary filter creation failed: %s", err_msg);
+
+        set_epan_auto_reset_count(3);
+        for (int i = 0; i < 5; i++) {
+            /* Alternate TCP/UDP to exercise both packets across the reset */
+            const unsigned char *pkt = (i % 2 == 0) ? PKT_TCP : PKT_UDP;
+            int pkt_len = (i % 2 == 0) ? (int)sizeof(PKT_TCP) : (int)sizeof(PKT_UDP);
+            marine_result *r = marine_dissect_packet(fid, (unsigned char *)pkt, pkt_len);
+            check(r->result == 1, "Reset-boundary: packet %d did not pass", i);
+            check(r->output[0] != NULL && strcmp(r->output[0], "4") == 0,
+                  "Reset-boundary: ip.version at pkt %d expected '4', got '%s'", i, r->output[0] ? r->output[0] : "(null)");
+            check(r->output[1] != NULL && strcmp(r->output[1], "1") == 0,
+                  "Reset-boundary: frame.encap_type at pkt %d expected '1', got '%s'", i, r->output[1] ? r->output[1] : "(null)");
+            marine_free(r);
+        }
+        set_epan_auto_reset_count(100000);
+    }
+
+    printf("All sanity checks passed.\n\n");
+}
+
 void run_dissect_packet_benchmarks(packet packets[], int packet_count, int encap_type) {
 
     char *bpf = "tcp portrange 4000-4019 or udp portrange 4000-4019";
@@ -227,6 +404,7 @@ int main(int argc, char *argv[]) {
         return -1;
     }
     init_marine();
+    validate_extraction();
     run_dissect_packet_benchmarks(packets, packet_count, encap_type);
     run_dissect_all_packet_fields_benchmarks(packets, packet_count, encap_type);
     destroy_marine();

--- a/marine_benchmark.c
+++ b/marine_benchmark.c
@@ -311,6 +311,82 @@ void validate_extraction(void) {
         set_epan_auto_reset_count(100000);
     }
 
+    /* --- 6. FT_PROTOCOL field triggers visible=TRUE fallback --- */
+    {
+        /* Requesting "ip" (FT_PROTOCOL) should trigger the fallback to
+         * visible=TRUE and still produce correct output. */
+        char *fields[] = { "ip", "ip.proto" };
+        int fid = marine_add_filter(NULL, NULL, fields, NULL, ARRAY_SIZE(fields), ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "FT_PROTOCOL filter creation failed: %s", err_msg);
+
+        marine_result *r = marine_dissect_packet(fid, (unsigned char *)PKT_TCP, sizeof(PKT_TCP));
+        check(r->result == 1, "FT_PROTOCOL: packet did not pass");
+        check(r->len == 2, "FT_PROTOCOL: expected 2 slots, got %u", r->len);
+        /* ip (FT_PROTOCOL): should be non-NULL with full representation */
+        check(r->output[0] != NULL, "FT_PROTOCOL: 'ip' field is NULL");
+        check(strlen(r->output[0]) > 2,
+              "FT_PROTOCOL: 'ip' field too short (got '%s'), expected full representation", r->output[0]);
+        /* ip.proto should still work alongside FT_PROTOCOL field */
+        check(r->output[1] != NULL && strcmp(r->output[1], "6") == 0,
+              "FT_PROTOCOL: ip.proto expected '6', got '%s'", r->output[1] ? r->output[1] : "(null)");
+        marine_free(r);
+    }
+
+    /* --- 7. Macro-index grouping: first non-empty field in each group wins --- */
+    {
+        /* Fields: [tcp.srcport, udp.srcport, ip.proto]
+         * Macros:  [0,           0,           1      ]
+         * For TCP: tcp.srcport present → macro 0 outputs it, ip.proto → macro 1.
+         * For UDP (first dissection): tcp.srcport empty → falls through to udp.srcport.
+         * Output count = 2 (two distinct macro groups). */
+        char *fields[] = { "tcp.srcport", "udp.srcport", "ip.proto" };
+        int macro_ids[] = { 0, 0, 1 };
+        int fid = marine_add_filter(NULL, NULL, fields, macro_ids, ARRAY_SIZE(fields), ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "Macro filter creation failed: %s", err_msg);
+
+        /* UDP first — tests fallthrough within a macro group */
+        marine_result *r1 = marine_dissect_packet(fid, (unsigned char *)PKT_UDP, sizeof(PKT_UDP));
+        check(r1->result == 1, "Macro UDP: packet did not pass");
+        check(r1->len == 2, "Macro UDP: expected 2 output slots, got %u", r1->len);
+        check(r1->output[0] != NULL && strcmp(r1->output[0], "4010") == 0,
+              "Macro UDP: slot 0 expected '4010' (udp.srcport), got '%s'", r1->output[0] ? r1->output[0] : "(null)");
+        check(r1->output[1] != NULL && strcmp(r1->output[1], "17") == 0,
+              "Macro UDP: slot 1 expected '17' (ip.proto), got '%s'", r1->output[1] ? r1->output[1] : "(null)");
+        marine_free(r1);
+
+        /* TCP second — tests first field in macro group matching directly */
+        marine_result *r2 = marine_dissect_packet(fid, (unsigned char *)PKT_TCP, sizeof(PKT_TCP));
+        check(r2->result == 1, "Macro TCP: packet did not pass");
+        check(r2->len == 2, "Macro TCP: expected 2 output slots, got %u", r2->len);
+        check(r2->output[0] != NULL && strcmp(r2->output[0], "4010") == 0,
+              "Macro TCP: slot 0 expected '4010' (tcp.srcport), got '%s'", r2->output[0] ? r2->output[0] : "(null)");
+        check(r2->output[1] != NULL && strcmp(r2->output[1], "6") == 0,
+              "Macro TCP: slot 1 expected '6' (ip.proto), got '%s'", r2->output[1] ? r2->output[1] : "(null)");
+        marine_free(r2);
+    }
+
+    /* --- 8. Multi-occurrence field with aggregation --- */
+    {
+        /* ip.host appears twice per packet (src + dst), aggregated with comma.
+         * For our TCP packet: src=88.44.85.145, dst=212.110.118.170 */
+        char *fields[] = { "ip.host" };
+        int fid = marine_add_filter(NULL, NULL, fields, NULL, ARRAY_SIZE(fields), ETHERNET_ENCAP, &err_msg);
+        check(fid >= 0, "Multi-occurrence filter creation failed: %s", err_msg);
+
+        marine_result *r = marine_dissect_packet(fid, (unsigned char *)PKT_TCP, sizeof(PKT_TCP));
+        check(r->result == 1, "Multi-occurrence: packet did not pass");
+        check(r->len == 1, "Multi-occurrence: expected 1 slot, got %u", r->len);
+        check(r->output[0] != NULL, "Multi-occurrence: ip.host is NULL");
+        /* Should contain both IPs comma-separated (occurrence='a', aggregator=',') */
+        check(strstr(r->output[0], "88.44.85.145") != NULL,
+              "Multi-occurrence: missing src IP in '%s'", r->output[0]);
+        check(strstr(r->output[0], "212.110.118.170") != NULL,
+              "Multi-occurrence: missing dst IP in '%s'", r->output[0]);
+        check(strstr(r->output[0], ",") != NULL,
+              "Multi-occurrence: missing comma aggregator in '%s'", r->output[0]);
+        marine_free(r);
+    }
+
     printf("All sanity checks passed.\n\n");
 }
 

--- a/marine_benchmark.c
+++ b/marine_benchmark.c
@@ -7,6 +7,9 @@
 #include <time.h>
 #include <stdlib.h>
 
+#define BENCH_RUNS 7
+#define BENCH_KEEP 3
+
 typedef struct {
     char *title;
     char *bpf;
@@ -52,12 +55,26 @@ int load_cap(char *file, packet **packets, char errbuff[PCAP_ERRBUF_SIZE]) {
     return p_count;
 }
 
-void print_benchmark_results(struct timespec start_time, struct timespec end_time, size_t memory_start, size_t memory_end, int packet_len) {
-    double total_time = (end_time.tv_sec - start_time.tv_sec) + ((end_time.tv_nsec - start_time.tv_nsec) * 1e-9);
-    double pps = packet_len / total_time;
+int compare_doubles(const void *a, const void *b) {
+    double da = *(const double *)a;
+    double db = *(const double *)b;
+    return (da > db) - (da < db);
+}
+
+double average_fastest_runs(double times[], int n, int keep) {
+    qsort(times, n, sizeof(double), compare_doubles);
+    double sum = 0;
+    for (int i = 0; i < keep; i++) {
+        sum += times[i];
+    }
+    return sum / keep;
+}
+
+void print_benchmark_results(double avg_time, size_t memory_start, size_t memory_end, int packet_len) {
+    double pps = packet_len / avg_time;
     double memory_usage = (memory_end - memory_start) / 1024.0 / 1024.0;
-    printf("%d packets took: %f Sec, which is %f pps!\nmemory usage: %lf MB\n", packet_len, total_time, pps,
-           memory_usage);
+    printf("%d packets took: %f Sec (avg of fastest %d/%d runs), which is %f pps!\nmemory usage: %lf MB\n",
+           packet_len, avg_time, BENCH_KEEP, BENCH_RUNS, pps, memory_usage);
 }
 
 void benchmark(packet packets[], int packet_len, char *bpf, char *display_filter, char *fields[], int* macro_indices, unsigned int fields_len, int encapsulation_type) {
@@ -65,25 +82,31 @@ void benchmark(packet packets[], int packet_len, char *bpf, char *display_filter
     int filter_id = marine_add_filter(bpf, display_filter, fields, macro_indices, fields_len, encapsulation_type, &err_msg);
     struct timespec start_time, end_time;
 
-
     if (filter_id < 0) {
         fprintf(stderr, "Error creating filter id: %s\n", err_msg);
         marine_free_err_msg(err_msg);
         return;
     }
 
+    double times[BENCH_RUNS];
     size_t memory_start = get_current_rss();
-    clock_gettime(CLOCK_MONOTONIC_RAW, &start_time);
-    for (int i = 0; i < packet_len; ++i) {
-        packet p = packets[i];
-        marine_result *result = marine_dissect_packet(filter_id, (char *) p.data, p.header->len);
-        assert(result->result == 1);
-        marine_free(result);
-    }
-    clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
-    size_t memory_end = get_current_rss();
 
-    print_benchmark_results(start_time, end_time, memory_start, memory_end, packet_len);
+    for (int run = 0; run < BENCH_RUNS; run++) {
+        clock_gettime(CLOCK_MONOTONIC_RAW, &start_time);
+        for (int i = 0; i < packet_len; ++i) {
+            packet p = packets[i];
+            marine_result *result = marine_dissect_packet(filter_id, (char *) p.data, p.header->len);
+            assert(result->result == 1);
+            marine_free(result);
+        }
+        clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
+        times[run] = (end_time.tv_sec - start_time.tv_sec) + ((end_time.tv_nsec - start_time.tv_nsec) * 1e-9);
+        printf("  run %d/%d: %f sec\n", run + 1, BENCH_RUNS, times[run]);
+    }
+
+    size_t memory_end = get_current_rss();
+    double avg_time = average_fastest_runs(times, BENCH_RUNS, BENCH_KEEP);
+    print_benchmark_results(avg_time, memory_start, memory_end, packet_len);
 }
 
 
@@ -93,19 +116,25 @@ int print_title(char *str) {
 
 void benchmark_dissect_all_packet_fields(packet packets[], int packet_len, int encapsulation_type) {
     struct timespec start_time, end_time;
-
+    double times[BENCH_RUNS];
 
     size_t memory_start = get_current_rss();
-    clock_gettime(CLOCK_MONOTONIC_RAW, &start_time);
-    for (int i = 0; i < packet_len; i++) {
-        packet p = packets[i];
-        marine_packet *pkt = marine_dissect_all_packet_fields((char *) p.data, p.header->len, encapsulation_type);
-        marine_packet_free(pkt);
-    }
-    clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
-    size_t memory_end = get_current_rss();
 
-    print_benchmark_results(start_time, end_time, memory_start, memory_end, packet_len);
+    for (int run = 0; run < BENCH_RUNS; run++) {
+        clock_gettime(CLOCK_MONOTONIC_RAW, &start_time);
+        for (int i = 0; i < packet_len; i++) {
+            packet p = packets[i];
+            marine_packet *pkt = marine_dissect_all_packet_fields((char *) p.data, p.header->len, encapsulation_type);
+            marine_packet_free(pkt);
+        }
+        clock_gettime(CLOCK_MONOTONIC_RAW, &end_time);
+        times[run] = (end_time.tv_sec - start_time.tv_sec) + ((end_time.tv_nsec - start_time.tv_nsec) * 1e-9);
+        printf("  run %d/%d: %f sec\n", run + 1, BENCH_RUNS, times[run]);
+    }
+
+    size_t memory_end = get_current_rss();
+    double avg_time = average_fastest_runs(times, BENCH_RUNS, BENCH_KEEP);
+    print_benchmark_results(avg_time, memory_start, memory_end, packet_len);
 }
 
 void run_dissect_packet_benchmarks(packet packets[], int packet_count, int encap_type) {


### PR DESCRIPTION
- Set up some better benchmark infra
- Manually replaced some hot-path heap allocations with stack ones for a good modest benefit on the BPF only path.

Then I let Claude Opus 4.6 loose on the codebase with a build-and-benchmark.sh script and it came up with some amazing results:
- a few more hot-path allocations that could be shaved off, nice
- TURNS OUT THERE'S SOME DISPLAY ONLY PARSING YOU CAN TOGGLE OFF
- TURNS OUT YOU CAN PRIME PARSING WITH ONLY RELEVANT FIELDS TO TRIM PARSING TREE

The results are quite fantastic, here's the benchmark comparison of this branch vs main branch (first ratio is PPS, second is additional memory from this step, mostly noise since it's practically zero, the last ratio is the total memory of the benchmark and you can see we do better):
<img width="676" height="136" alt="image" src="https://github.com/user-attachments/assets/b9d7885a-7c44-403c-8b74-afb9fd3573b5" />